### PR TITLE
实现readme里面的"通过快捷键提权"的功能

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2024  yanglx2022 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setting.ini
+++ b/setting.ini
@@ -3,20 +3,9 @@
 #CA|Q|SnapShot.exe#		Ctrl+Alt+Q 打开SnapShot.exe截图程序
 #CA|W|QRCode.exe|[clipboard]# 	Ctrl+Alt+W 以剪切板文本为参数打开QRCode.exe二维码生成程序
 #CA|P|C:\WINDOWS\system32\mspaint.exe# 画图
-#CA|F|"C:\Program Files (Green)\Tools\Everything1.2.1\Everything-1.2.1.371.exe"# 搜索
 #CA|C|C:\Windows\System32\calc.exe# 计算器
 #CA|M|C:\Windows\System32\cmd.exe# CMD
-#C|IP|"C:\Program Files (Green)\Tools\ShortCut\_ipconfig.bat"# ipconfig
 #CA|R|C:\Windows\regedit.exe# 注册表编辑器
-#CA|N|"C:\Program Files (x86)\Notepad++\notepad++.exe"# Notepad++
-#CA|S|C:\Windows\System32\notepad.exe "C:\Users\Yang\Temp\写字板.txt"# 记事本
-#CA|A|"C:\Program Files (Green)\Tools\ShortCut\SnippingTool\SnippingTool.exe"# 截图
-#CA|Z|explorer "C:\Users\YANG\Temp\"# 
-#CA|D|explorer C:\Users\YANG\Documents\# 
-#CA|E|explorer "C:\Program Files (Green)\Tools\ShortCut\"# 
-#CA|G|explorer "C:\Users\Yang\Documents\Snippets\"#
-#CA|L|explorer "C:\Users\Yang\CLionProjects\"#
-#CA|J|explorer "C:\Users\Yang\Documents\Java\"#
 #####
 
 


### PR DESCRIPTION
改动有两处，若 @yanglx2022 觉得合适，请酌情合并
 - 程序原本的实现是自动提权，现改为与readme一致，通过快捷键提权
 - 在setting.ini中删除大部分在一般机器上无效的配置，仅保留"#CA|W|QRCode.exe|[clipboard]"做为示例(更适合作为公共发布分支的内容)